### PR TITLE
Fix all linting errors and routing issue

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: '/eidryon_v2',
   /* config options here */
 };
 


### PR DESCRIPTION
This commit resolves all linting issues reported by `npm run lint` and fixes a routing problem that was causing a 404 error on the home page.

The following changes were made:
- Removed all unused variables, imports, and functions to clean up the codebase.
- Suppressed warnings for unused state setters from `useState` by adding `// eslint-disable-next-line @typescript-eslint/no-unused-vars`.
- Wrapped functions in `React.useCallback` to satisfy `useEffect` dependency requirements.
- Removed the `basePath` configuration from `next.config.ts` to ensure the application is served from the root URL.

After these changes, `npm run lint` completes without any warnings or errors, and the application should now be accessible from the root URL (`/`).