### PR TITLE
Fix TypeScript type error in AnalystView

### DIFF
--- a/src/app/analyst/page.tsx
+++ b/src/app/analyst/page.tsx
@@ -37,6 +37,21 @@ type IntelReport = {
   correlatedReports?: IntelReport[];
 };
 
+type TopSource = {
+  source: Source;
+  count: number;
+  reliability: number;
+};
+
+type AnalyticsData = {
+  totalReports: number;
+  newReports24h: number;
+  highPriorityReports: number;
+  verifiedReports: number;
+  avgConfidence: number;
+  topSources: TopSource[];
+};
+
 
 const AnalystView = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -123,7 +138,7 @@ const AnalystView = () => {
   ]);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [analyticsData, setAnalyticsData] = useState({
+  const [analyticsData, setAnalyticsData] = useState<AnalyticsData>({
     totalReports: 156,
     newReports24h: 24,
     highPriorityReports: 8,


### PR DESCRIPTION
This commit fixes a TypeScript type error in `src/app/analyst/page.tsx`. The `getSourceIcon` function was being called with an argument of type `string` instead of `Source`.

This was resolved by:
1.  Defining types for `TopSource` and `AnalyticsData`.
2.  Using the `AnalyticsData` type for the `analyticsData` state.

This ensures that the `source.source` property is correctly typed as `Source` within the component, resolving the build error.