### PR TITLE
Fix TypeScript type error for ThreatLevel in AnalystView

### DIFF
--- a/src/app/analyst/page.tsx
+++ b/src/app/analyst/page.tsx
@@ -52,6 +52,16 @@ type AnalyticsData = {
   topSources: TopSource[];
 };
 
+type Threat = {
+  id: string;
+  type: string;
+  threat_level: ThreatLevel;
+  location: { lat: number; lng: number };
+  confidence: number;
+  range: number;
+  description: string;
+};
+
 
 const AnalystView = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -116,7 +126,7 @@ const AnalystView = () => {
   ]);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [threatAssessment, setThreatAssessment] = useState([
+  const [threatAssessment, setThreatAssessment] = useState<Threat[]>([
     {
       id: 'THR-001',
       type: 'SAM_SITE',


### PR DESCRIPTION
This commit fixes a TypeScript type error in `src/app/analyst/page.tsx`. The `getThreatLevelColor` function was being called with an argument of type `string` instead of `ThreatLevel`.

This was resolved by:
1.  Defining a `Threat` type.
2.  Using the `Threat[]` type for the `threatAssessment` state.

This ensures that the `threat.threat_level` property is correctly typed as `ThreatLevel` within the component, resolving the build error.