### PR TITLE
Fix TypeScript error with Date arithmetic in AnalystView

### DIFF
--- a/src/app/analyst/page.tsx
+++ b/src/app/analyst/page.tsx
@@ -556,7 +556,7 @@ const AnalystView = () => {
                       {report.classification}
                     </div>
                     <div className="text-xs font-mono text-gray-400">
-                      {Math.floor((new Date() - report.timestamp) / 60000)}m ago
+                      {Math.floor((new Date().getTime() - report.timestamp.getTime()) / 60000)}m ago
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This commit fixes a TypeScript type error in `src/app/analyst/page.tsx`. The build was failing because of an attempt to directly subtract two `Date` objects.

This was resolved by using the `.getTime()` method to get the numeric value of each `Date` object before performing the subtraction. This makes the operation explicit and resolves the type error.