### PR TITLE
Fix TypeScript type error for new events in CommanderView

### DIFF
--- a/src/app/commander/page.tsx
+++ b/src/app/commander/page.tsx
@@ -190,7 +190,7 @@ const CommanderView = () => {
 
     // 새로운 이벤트 추가 (20% 확률)
     if (Math.random() < 0.2) {
-      const newEvent = {
+      const newEvent: RecentEvent = {
         id: Date.now(),
         time: new Date().toLocaleTimeString(),
         type: Math.random() > 0.7 ? 'ALERT' : Math.random() > 0.5 ? 'WARNING' : 'INFO',


### PR DESCRIPTION
This commit fixes a TypeScript type error in `src/app/commander/page.tsx`. The build was failing because the `newEvent` object had its `type` and `priority` properties inferred as `string` instead of the more specific `EventType` and `Priority` types.

This was resolved by adding an explicit type annotation (`RecentEvent`) to the `newEvent` object upon its creation.

This ensures that the `newEvent` object conforms to the `RecentEvent` type, resolving the build error.