### PR TITLE
Fix GitHub Actions deployment permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The GitHub Actions workflow was failing during the deployment step due to a permissions error. The `peaceiris/actions-gh-pages` action requires `contents: write` permission to push the built static site to the `gh-pages` branch.

This permission was not configured in the workflow file, causing the `git push` command to fail with a 403 Forbidden error.

This change adds the `permissions: contents: write` block to the `build-and-deploy` job in `.github/workflows/deploy.yml` to grant the necessary permissions to the `GITHUB_TOKEN`.