### PR TITLE
Fix broken links on GitHub Pages by setting basePath

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
+  basePath: '/eidryon_v2',
   /* config options here */
 };
 


### PR DESCRIPTION
The deployed GitHub Pages site had broken links for CSS, JS, and other assets. This was because the Next.js application was not aware that it was being served from a subdirectory (`/eidryon_v2`).

This change re-instates the `basePath: '/eidryon_v2'` configuration in `next.config.ts`. This ensures that all asset links are generated with the correct prefix, resolving the 404 errors for assets on the deployed site.