### PR TITLE
Fix asset paths on GitHub Pages with assetPrefix

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: 'export',
   basePath: '/eidryon_v2',
+  assetPrefix: '/eidryon_v2',
   /* config options here */
 };
 


### PR DESCRIPTION
The deployed GitHub Pages site was still failing to load static assets (CSS, JS, fonts), resulting in 404 errors. This was happening because the asset URLs were not being correctly prefixed with the repository path (`/eidryon_v2`).

While `basePath` was set correctly, it was not sufficient to fix all asset links.

This change adds the `assetPrefix: '/eidryon_v2'` configuration to `next.config.ts`. This works in conjunction with `basePath` to ensure all static assets are requested from the correct sub-path, which should resolve the 404 errors.