### PR TITLE
fix: Add unoptimized images config for static export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   output: 'export',
   basePath: '/eidryon_v2',
   assetPrefix: '/eidryon_v2',
+  images: {
+    unoptimized: true,
+  },
   /* config options here */
 };
 


### PR DESCRIPTION
This commit adds `images: { unoptimized: true }` to the `next.config.ts` file.

This is a troubleshooting step to resolve an issue where static assets (CSS) are not loading correctly on the GitHub Pages deployment. For static exports (`output: 'export'`), the default Next.js image optimizer is not available. Explicitly disabling it is often required and can sometimes resolve related asset pathing issues during the build process.