### PR TITLE
ci: Enable npm cache in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The deployment workflow was intermittently failing during the `npm install` step with a "429 Too Many Requests" error from the npm registry. This indicates that the GitHub Actions runner was being rate-limited.

This commit adds caching for npm dependencies to the `setup-node` action. This will significantly speed up the `npm install` step on subsequent runs and, more importantly, reduce the number of requests made to the npm registry, preventing future rate-limiting errors.