### PR TITLE
Fix root page 404 by removing basePath

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: '/eidryon_v2',
-  assetPrefix: '/eidryon_v2',
   images: {
     unoptimized: true,
   },

--- a/npm_dev.log
+++ b/npm_dev.log
@@ -1,5 +1,4 @@
 
 > new_app@0.1.0 dev
-> next dev --turbopack
+> next dev
 
- ⚠ Port 3000 is in use by an unknown process, using available port 3001 instead.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build && touch out/.nojekyll",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
The application was returning a 404 error for the root URL ('/') because the Next.js configuration included a `basePath`. This setting moves the application's root to the specified path, in this case, '/eidryon_v2'.

This change removes the `basePath` and `assetPrefix` from `next.config.ts`, restoring the application's root to '/' and resolving the 404 error.

Additionally, the `--turbopack` flag was removed from the `dev` script in `package.json` to troubleshoot issues with starting the development server.